### PR TITLE
Added pgadmin and default server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ the repo history.
 @edwinabot tested this successfully in Ubuntu 22.04 running on WSL2 with Docker Desktop 4.16.3 (96739).
 [Installed act](https://github.com/nektos/act#bash-script) via Bash script.
 
+## PostgreSQL & pgAdmin
+
+The dev environment comes with [pgAdmin](https://www.pgadmin.org/) configured so you can query the local PostgreSQL instance. After `docker compose up` you can access pgAdmin at http://localhost:5050
+
+Look at the [.env.example](local-dev/.env.example) for default users and passwords for Postgres and pgAdmin. The env vars are:
+
+* POSTGRES_DB_USERNAME
+* POSTGRES_DB_PASSWORD
+* PGADMIN_DEFAULT_EMAIL
+* PGADMIN_DEFAULT_PASSWORD
+
+Exploring the configured servers for the first time in pgAdmin will propt for the password for the server, that is POSTGRES_DB_PASSWORD.
 ## Notes
 
 ### Why the Dockerfile is at the root of the project and not in local-dev?

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Look at the [.env.example](local-dev/.env.example) for default users and passwor
 * PGADMIN_DEFAULT_EMAIL
 * PGADMIN_DEFAULT_PASSWORD
 
-Exploring the configured servers for the first time in pgAdmin will propt for the password for the server, that is POSTGRES_DB_PASSWORD.
+Exploring the configured servers for the first time in pgAdmin will prompt for the password for the server, that is POSTGRES_DB_PASSWORD.
 ## Notes
 
 ### Why the Dockerfile is at the root of the project and not in local-dev?

--- a/local-dev/.env.example
+++ b/local-dev/.env.example
@@ -1,8 +1,8 @@
 S3_BUCKET_NAME=sampledata
 
 # POSTGRES_DB_ENGINE
-POSTGRES_DB_PASSWORD=supersecurepassword
-POSTGRES_DB_USERNAME=veryimportantuser
+POSTGRES_DB_USERNAME=username
+POSTGRES_DB_PASSWORD=password
 POSTGRES_DB_PORT=5432
 POSTGRES_DB_HOST=postgresql
 POSTGRES_DB_NAME=exampledb
@@ -29,3 +29,6 @@ AWS_ENDPOINT_URL=http://localstack:4566
 # Docker Compose Env vars
 #
 WORKDIR=/home/glue_user/workspace/
+PGADMIN_DEFAULT_EMAIL=pgadmin4@pgadmin.org
+PGADMIN_DEFAULT_PASSWORD=password
+PGADMIN_SERVER_JSON_FILE=/pgadmin4/bootstrap/servers.json

--- a/local-dev/docker-compose.yaml
+++ b/local-dev/docker-compose.yaml
@@ -67,6 +67,24 @@ services:
     networks:
       - aws-glue-boilerplate
 
+  pgadmin:
+    container_name: pgadmin4
+    image: dpage/pgadmin4:latest
+    restart: always
+    depends_on:
+      - postgresql
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_SERVER_JSON_FILE: ${PGADMIN_SERVER_JSON_FILE}
+    ports:
+      - 5050:80
+    networks:
+      - aws-glue-boilerplate
+    volumes:
+      - ./pgadmin-bootstrap/:/pgadmin4/bootstrap/
+
+
 networks:
   aws-glue-boilerplate:
     driver: "bridge"

--- a/local-dev/pgadmin-bootstrap/servers.json
+++ b/local-dev/pgadmin-bootstrap/servers.json
@@ -1,0 +1,22 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "AWS Glue Boilerplate",
+      "Group": "Servers",
+      "Host": "postgresql",
+      "Port": 5432,
+      "MaintenanceDB": "postgres",
+      "Username": "username",
+      "UseSSHTunnel": 0,
+      "TunnelPort": "22",
+      "TunnelAuthentication": 0,
+      "KerberosAuthentication": false,
+      "ConnectionParameters": {
+        "sslmode": "prefer",
+        "connect_timeout": 10,
+        "sslcert": "<STORAGE_DIR>/.postgresql/postgresql.crt",
+        "sslkey": "<STORAGE_DIR>/.postgresql/postgresql.key"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What:** Added pgadmin4

**Why:** So devs can query easily the local postgres instance

**How:** added pgadmin to compose, also included a default config file so the local postgres instance is immediatelly accessible from pgadmin